### PR TITLE
The endpoints /metadata/all and metadata/data-structures now accept the

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
             python3-distutils \
             python3-apt \
             libpython3.9-dev
-          curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python -
+          curl -sSL https://install.python-poetry.org | python3 -
           source $HOME/.poetry/env
           poetry install
         displayName: 'Install dependencies'

--- a/metadata_service/api/metadata_api.py
+++ b/metadata_service/api/metadata_api.py
@@ -40,7 +40,8 @@ def get_data_structures(query: MetadataQuery):
     response = jsonify(metadata.find_data_structures(
         query.names,
         query.version,
-        query.include_attributes
+        query.include_attributes,
+        query.skip_code_lists
     ))
     response.headers.set('content-language', 'no')
     return response
@@ -52,7 +53,8 @@ def get_all_metadata(query: MetadataQuery):
     logger.info(f'GET /metadata/all with version: {query.version}')
 
     response = jsonify(metadata.find_all_metadata(
-        query.version
+        query.version,
+        query.skip_code_lists
     ))
     response.headers.set('content-language', 'no')
     return response

--- a/metadata_service/api/request_models.py
+++ b/metadata_service/api/request_models.py
@@ -14,6 +14,7 @@ class MetadataQuery(BaseModel, extra=Extra.forbid, validate_assignment=True):
     names: List[str] = []
     version: str
     include_attributes: bool = False
+    skip_code_lists : bool = False
 
     @validator('names', pre=True)
     @classmethod

--- a/metadata_service/domain/metadata.py
+++ b/metadata_service/domain/metadata.py
@@ -76,12 +76,12 @@ def find_all_metadata_skip_code_list_and_missing_values(version):
     metadata = datastore.get_metadata_all(version)
      
     if 'dataStructures' in metadata:
-        __clear_code_list_and_missing_values(metadata['dataStructures'])
+        _clear_code_list_and_missing_values(metadata['dataStructures'])
     else:
-        __clear_code_list_and_missing_values(metadata)
+        _clear_code_list_and_missing_values(metadata)
     return metadata
 
-def __clear_code_list_and_missing_values(metadata):
+def _clear_code_list_and_missing_values(metadata):
     for md in metadata:
         for av in md['attributeVariables']:
             for rv in av['representedVariables']:

--- a/metadata_service/domain/metadata.py
+++ b/metadata_service/domain/metadata.py
@@ -78,7 +78,7 @@ def find_all_metadata_skip_code_list_and_missing_values(version):
     if 'dataStructures' in metadata:
         _clear_code_list_and_missing_values(metadata['dataStructures'])
     else:
-        _clear_code_list_and_missing_values(metadata)
+        raise DataNotFoundException(f'Expected dataStructures')
     return metadata
 
 def _clear_code_list_and_missing_values(metadata):

--- a/metadata_service/domain/metadata.py
+++ b/metadata_service/domain/metadata.py
@@ -2,7 +2,7 @@ from typing import List
 
 from metadata_service.adapter import datastore
 from metadata_service.exceptions.exceptions import DataNotFoundException
-
+import json
 
 def find_all_datastore_versions():
     draft_version = datastore.get_draft_version()
@@ -40,15 +40,17 @@ def find_current_data_structure_status(datastructure_name: str):
 
 
 def find_data_structures(
-    names: List[str], version: str, include_attributes: bool
+    names: List[str], version: str, include_attributes: bool, skip_code_lists: bool = False
 ):
-    metadata_all = datastore.get_metadata_all(version)
+    metadata = datastore.get_metadata_all(version) if not skip_code_lists \
+        else find_all_metadata_skip_code_list_and_missing_values(version) 
+
     if names:
         matched = [
-            ds for ds in metadata_all['dataStructures'] if ds['name'] in names
+            ds for ds in metadata['dataStructures'] if ds['name'] in names
         ]
     else:
-        matched = metadata_all['dataStructures']
+        matched = metadata['dataStructures']
 
     for match in matched:
         if not include_attributes:
@@ -56,9 +58,11 @@ def find_data_structures(
     return matched
 
 
-def find_all_metadata(version):
-    return datastore.get_metadata_all(version)
-
+def find_all_metadata(version, skip_code_lists: bool = False):
+    if not skip_code_lists:
+        return datastore.get_metadata_all(version)
+    else:
+        return find_all_metadata_skip_code_list_and_missing_values(version)
 
 def find_languages():
     return [
@@ -67,3 +71,34 @@ def find_languages():
             'label': 'Norsk'
         },
     ]
+
+def find_all_metadata_skip_code_list_and_missing_values(version):
+    metadata = datastore.get_metadata_all(version)
+     
+    if 'dataStructures' in metadata:
+        __clear_code_list_and_missing_values(metadata['dataStructures'])
+    else:
+        __clear_code_list_and_missing_values(metadata)
+    return metadata
+
+def __clear_code_list_and_missing_values(metadata):
+    for md in metadata:
+        for av in md['attributeVariables']:
+            for rv in av['representedVariables']:
+                if 'codeList' in rv['valueDomain']:
+                    rv['valueDomain']['codeList'].clear()
+                if 'missingValues' in rv['valueDomain']:
+                    rv['valueDomain']['missingValues'].clear()
+        for iv in md['identifierVariables']:
+            for rv in iv['representedVariables']:
+                if 'codeList' in rv['valueDomain']:
+                    rv['valueDomain']['codeList'].clear()
+                if 'missingValues' in rv['valueDomain']:
+                    rv['valueDomain']['missingValues'].clear()
+        for rv in md['measureVariable']['representedVariables']:
+                if 'codeList' in rv['valueDomain']:
+                    rv['valueDomain']['codeList'].clear()
+                if 'missingValues' in rv['valueDomain']:
+                    rv['valueDomain']['missingValues'].clear()
+    
+    return metadata

--- a/tests/resources/fixtures/api/data_structures_no_code_list.json
+++ b/tests/resources/fixtures/api/data_structures_no_code_list.json
@@ -1,0 +1,202 @@
+[
+  {
+    "attributeVariables": [
+      {
+        "name": "END",
+        "label": "End",
+        "dataType": "Instant",
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": 10957
+            },
+            "valueDomain": {
+              "missingValues": [],
+              "codeList": []
+            },
+            "description": "Stoppdato for forløpsdata."
+          }
+        ],
+        "variableRole": "Stop",
+        "format": "yyyy-mm-dd"
+      },
+      {
+        "dataType": "Instant",
+        "label": "Start",
+        "name": "START",
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": 10957
+            },
+            "valueDomain": {
+              "missingValues": [],
+              "codeList": []
+            },
+            "description": "Startdato for forløpsdata eller måletidspunkt for statusdata/tverrsnittsdata."
+          }
+        ],
+        "variableRole": "Start",
+        "format": "yyyy-mm-dd"
+      }
+    ],
+    "identifierVariables": [
+      {
+        "label": "Fødselsnummer kryptert (HASH)",
+        "dataType": "Long",
+        "name": "FNR_HASH",
+        "keyType": {
+          "description": "Person",
+          "label": "Person",
+          "name": "PERSON"
+        },
+        "format": "RandomUInt64",
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": 10957
+            },
+            "valueDomain": {
+              "missingValues": [],
+              "codeList": []
+            },
+            "description": "Person identifisert med kryptert (HASH) fødselsnummer."
+          }
+        ],
+        "variableRole": "Identifier"
+      }
+    ],
+    "measureVariable": {
+      "dataType": "String",
+      "label": "Fødselsnummer",
+      "name": "FNR",
+      "keyType": {
+        "description": "Person",
+        "label": "Person",
+        "name": "PERSON"
+      },
+      "format": "RandomUInt64",
+      "representedVariables": [
+        {
+          "validPeriod": {
+            "start": 10957
+          },
+          "valueDomain": {
+            "missingValues": [],
+            "codeList": []
+          },
+          "description": "Variabelen viser fødselsnummer, det vil si fødselsdag, -måned og -år (6 siffer) og personnummer (5 siffer)"
+        }
+      ],
+      "variableRole": "Measure"
+    },
+    "name": "FNR",
+    "temporality": "EVENT",
+    "temporalCoverage": {
+      "start": 10957,
+      "stop": 16435
+    },
+    "subjectFields": [
+      "ARBEID_LONN"
+    ],
+    "languageCode": "no"
+  },
+  {
+    "attributeVariables": [
+      {
+        "dataType": "Instant",
+        "label": "End",
+        "name": "END",
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": 10957
+            },
+            "valueDomain": {
+              "missingValues": [],
+              "codeList": []
+            },
+            "description": "Stoppdato for forløpsdata."
+          }
+        ],
+        "variableRole": "Stop"
+      },
+      {
+        "dataType": "Instant",
+        "label": "Start",
+        "name": "START",
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": 10957
+            },
+            "valueDomain": {
+              "missingValues": [],
+              "codeList": []
+            },
+            "description": "Startdato for forløpsdata eller måletidspunkt for statusdata/tverrsnittsdata."
+          }
+        ],
+        "variableRole": "Start"
+      }
+    ],
+    "identifierVariables": [
+      {
+        "dataType": "Long",
+        "label": "Fødselsnummer kryptert (HASH)",
+        "name": "FNR_HASH",
+        "keyType": {
+          "description": "Person",
+          "label": "Person",
+          "name": "PERSON"
+        },
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": 10957
+            },
+            "valueDomain": {
+              "missingValues": [],
+              "codeList": []
+            },
+            "description": "Person identifisert med kryptert (HASH) fødselsnummer."
+          }
+        ],
+        "variableRole": "Identifier"
+      }
+    ],
+    "measureVariable": {
+      "dataType": "String",
+      "label": "Arbeidsavklaringspenger",
+      "name": "AKT_ARBAP",
+      "keyType": {
+        "description": "Person",
+        "label": "Person",
+        "name": "PERSON"
+      },
+      "representedVariables": [
+        {
+          "validPeriod": {
+            "start": 10957
+          },
+          "valueDomain": {
+            "missingValues": [],
+            "codeList": []
+          },
+          "description": "Stønad som skal sikre inntekt i perioder der en person på grunn av sykdom eller skade har behov for bistand fra NAV for å komme i arbeid (inkl. etterbetalinger fra tidligere år)."
+        }
+      ],
+      "variableRole": "Measure"
+    },
+    "name": "AKT_ARBAP",
+    "temporality": "EVENT",
+    "temporalCoverage": {
+      "start": 14610,
+      "stop": 16070
+    },
+    "subjectFields": [
+      "ARBEID_LONN"
+    ],
+    "languageCode": "no"
+  }
+]

--- a/tests/resources/fixtures/domain/metadata_all_no_code_list__1_0_0_0.json
+++ b/tests/resources/fixtures/domain/metadata_all_no_code_list__1_0_0_0.json
@@ -1,0 +1,206 @@
+{
+  "dataStore": {
+    "name": "no.ssb.test",
+    "label": "Test data fra SSB",
+    "description": "Syntetiske registerdata som inngår i SSBs test",
+    "languageCode": "no"
+  },
+  "dataStructures": [
+    {
+      "attributeVariables": [
+        {
+          "name": "START",
+          "label": "Startdato",
+          "representedVariables": [
+            {
+              "validPeriod": {
+                "start": 16801,
+                "stop": 18261
+              },
+              "description": "Startdato/måletidspunktet for hendelsen",
+              "valueDomain": {
+                "description": "N/A",
+                "unitOfMeasure": "N/A"
+              }
+            }
+          ],
+          "dataType": "Instant",
+          "variableRole": "Start"
+        },
+        {
+          "name": "STOP",
+          "label": "Stoppdato",
+          "representedVariables": [
+            {
+              "validPeriod": {
+                "start": 16801,
+                "stop": 18261
+              },
+              "description": "Stoppdato/sluttdato for hendelsen",
+              "valueDomain": {
+                "description": "N/A",
+                "unitOfMeasure": "N/A"
+              }
+            }
+          ],
+          "dataType": "Instant",
+          "variableRole": "Stop"
+        }
+      ],
+      "identifierVariables": [
+        {
+          "name": "PERSON_ID_1",
+          "label": "Personidentifikator",
+          "dataType": "Long",
+          "representedVariables": [
+            {
+              "validPeriod": {
+                "start": 16801,
+                "stop": 18261
+              },
+              "description": "Identifikator for person",
+              "valueDomain": {
+                "description": "N/A",
+                "unitOfMeasure": "N/A"
+              }
+            }
+          ],
+          "keyType": {
+            "name": "PERSON",
+            "label": "Person",
+            "description": "Statistisk enhet er person (individ, enkeltmenneske)."
+          },
+          "format": "RandomUInt48",
+          "variableRole": "Identifier"
+        }
+      ],
+      "measureVariable": {
+        "name": "TEST_PERSON_INCOME",
+        "label": "Inntekt",
+        "dataType": "Long",
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": 16801,
+              "stop": 18261
+            },
+            "description": "Personinntekt.",
+            "valueDomain": {
+              "description": "Personinntekt i norske kroner (NOK)."
+            }
+          }
+        ],
+        "variableRole": "Measure"
+      },
+      "name": "TEST_PERSON_INCOME",
+      "populationDescription": "Alle personer med inntekt.",
+      "temporality": "ACCUMULATED",
+      "temporalCoverage": {
+        "start": 16801,
+        "stop": 18261
+      },
+      "subjectFields": [
+        "Inntekt"
+      ],
+      "languageCode": "no"
+    },
+    {
+      "attributeVariables": [
+        {
+          "name": "START",
+          "label": "Startdato",
+          "representedVariables": [
+            {
+              "validPeriod": {
+                "start": 5562,
+                "stop": 18579
+              },
+              "description": "Startdato/måletidspunktet for hendelsen",
+              "valueDomain": {
+                "description": "N/A",
+                "unitOfMeasure": "N/A"
+              }
+            }
+          ],
+          "dataType": "Instant",
+          "variableRole": "Start"
+        },
+        {
+          "name": "STOP",
+          "label": "Stoppdato",
+          "representedVariables": [
+            {
+              "validPeriod": {
+                "start": 5562,
+                "stop": 18579
+              },
+              "description": "Stoppdato/sluttdato for hendelsen",
+              "valueDomain": {
+                "description": "N/A",
+                "unitOfMeasure": "N/A"
+              }
+            }
+          ],
+          "dataType": "Instant",
+          "variableRole": "Stop"
+        }
+      ],
+      "identifierVariables": [
+        {
+          "name": "PERSON_ID_1",
+          "label": "Personidentifikator",
+          "dataType": "Long",
+          "representedVariables": [
+            {
+              "validPeriod": {
+                "start": 5562,
+                "stop": 18579
+              },
+              "description": "Identifikator for person",
+              "valueDomain": {
+                "description": "N/A",
+                "unitOfMeasure": "N/A"
+              }
+            }
+          ],
+          "keyType": {
+            "name": "PERSON",
+            "label": "Person",
+            "description": "Statistisk enhet er person (individ, enkeltmenneske)."
+          },
+          "format": "RandomUInt48",
+          "variableRole": "Identifier"
+        }
+      ],
+      "measureVariable": {
+        "name": "TEST_PERSON_PETS",
+        "label": "Kjæledyr",
+        "dataType": "String",
+        "representedVariables": [
+          {
+            "description": "Mine kjæledyr.",
+            "validPeriod": {
+              "start": 0
+            },
+            "valueDomain": {
+              "codeList": [],
+              "missingValues": []
+            }
+          }
+        ],
+        "variableRole": "Measure"
+      },
+      "name": "TEST_PERSON_PETS",
+      "populationDescription": "Alle personer som eier et kjæledyr.",
+      "temporality": "EVENT",
+      "temporalCoverage": {
+        "start": 5562,
+        "stop": 18579
+      },
+      "subjectFields": [
+        "Befolkning"
+      ],
+      "languageCode": "no"
+    }
+  ]
+}

--- a/tests/unit/domain/test_metadata.py
+++ b/tests/unit/domain/test_metadata.py
@@ -12,6 +12,9 @@ DATASTORE_VERSIONS_FILE_PATH = (
 DRAFT_VERSION_FILE_PATH = (
     'tests/resources/fixtures/domain/draft_version.json'
 )
+DATA_STRUCTURES_FILE_PATH = (
+    'tests/resources/fixtures/api/data_structures.json'
+)
 
 
 def test_find_two_data_structures_with_attrs(mocker):
@@ -24,10 +27,11 @@ def test_find_two_data_structures_with_attrs(mocker):
     actual = metadata.find_data_structures(
         ['TEST_PERSON_INCOME', 'TEST_PERSON_PETS'],
         '1_0_0',
-        True
+        True,
+        skip_code_lists=False
     )
     assert len(actual) == 2
-    income = next(
+    income = next(  
         data_structure for data_structure
         in mocked_metadata_all["dataStructures"]
         if data_structure["name"] == 'TEST_PERSON_INCOME'
@@ -51,7 +55,8 @@ def test_find_two_data_structures_without_attrs(mocker):
     actual = metadata.find_data_structures(
         ['TEST_PERSON_INCOME', 'TEST_PERSON_PETS'],
         '1_0_0',
-        False
+        False,
+        skip_code_lists=False
     )
     assert len(actual) == 2
     income = next(
@@ -78,7 +83,8 @@ def test_find_data_structures_no_name_filter(mocker):
     actual = metadata.find_data_structures(
         [],
         '1_0_0',
-        True
+        True,
+        skip_code_lists=False
     )
     assert len(actual) == 2
 
@@ -164,3 +170,51 @@ def test_find_all_datastore_versions_when_draft_version_empty(mocker):
     actual = metadata.find_all_datastore_versions()
     assert len(actual['versions']) == 1
     assert actual['versions'][0]['version'] == '1.0.0.0'
+
+def test_find_all_metadata_skip_code_list_and_missing_values_for_data_structures(mocker):
+    
+    with open(DATA_STRUCTURES_FILE_PATH, encoding='utf-8') as f:
+        mocked_data_structures = json.load(f)
+
+    mocker.patch.object(
+        datastore, 'get_metadata_all',
+        return_value=mocked_data_structures
+    )
+    
+    filtered_metadata = metadata.find_all_metadata_skip_code_list_and_missing_values(version='1.0.0.0')
+    __assert_code_list_and_missing_values(filtered_metadata)
+
+def test_find_all_metadata_skip_code_list_and_missing_values_for_data_structures(mocker):
+    
+    with open(METADATA_ALL_FILE_PATH, encoding='utf-8') as f:
+        mocked_metadata_all = json.load(f)
+
+    mocker.patch.object(
+        datastore, 'get_metadata_all',
+        return_value=mocked_metadata_all
+    )
+    
+    filtered_metadata = metadata.find_all_metadata_skip_code_list_and_missing_values(version='1.0.0.0')
+    __assert_code_list_and_missing_values(filtered_metadata['dataStructures'])
+
+def __assert_code_list_and_missing_values(metadata):
+
+    for md in metadata:
+        for av in md['attributeVariables']:
+            for rv in av['representedVariables']:
+                if 'codeLists' in rv['valueDomain']: 
+                    assert rv['valueDomain']['codeList'] == []
+                if 'missingValues' in rv['valueDomain']: 
+                    assert rv['valueDomain']['missingValues'] == []     
+        for iv in md['identifierVariables']:
+            for rv in iv['representedVariables']:
+                if 'codeList' in rv['valueDomain']:
+                    assert rv['valueDomain']['codeList'] == []
+                if 'missingValues' in rv['valueDomain']:
+                    assert rv['valueDomain']['missingValues'] == []
+        for rv in md['measureVariable']['representedVariables']:
+            if 'codeList' in rv['valueDomain']: 
+                assert rv['valueDomain']['codeList'] == []
+            if 'missingValues' in rv['valueDomain']: 
+                assert rv['valueDomain']['missingValues'] == []
+

--- a/tests/unit/domain/test_metadata.py
+++ b/tests/unit/domain/test_metadata.py
@@ -1,7 +1,8 @@
 import json
-
+import pytest
 from metadata_service.adapter import datastore
 from metadata_service.domain import metadata
+from metadata_service.exceptions.exceptions import DataNotFoundException
 
 METADATA_ALL_FILE_PATH = (
     'tests/resources/fixtures/domain/metadata_all.json'
@@ -196,7 +197,7 @@ def test_find_all_metadata_skip_code_list_and_missing_values_for_metadata_all(mo
 
     assert metadata_no_code_list == filtered_metadata
 
-def test_find_all_metadata_skip_code_list_and_missing_values_for_data_structures(mocker):
+def test_find_all_metadata_skip_code_list_and_missing_values_for_fails_for_data_structures(mocker):
     
     with open(DATA_STRUCTURES_FILE_PATH, encoding='utf-8') as f:
         mocked_data_structures = json.load(f)
@@ -206,13 +207,8 @@ def test_find_all_metadata_skip_code_list_and_missing_values_for_data_structures
         return_value=mocked_data_structures
     )
     
-    filtered_metadata = metadata.find_all_metadata_skip_code_list_and_missing_values(version='1.0.0.0')
-    __assert_code_list_and_missing_values(filtered_metadata)
-
-    with open(DATA_STRUCTURES_NO_CODE_LIST_FILE_PATH, encoding='utf-8') as f:
-        data_structures_no_code_list = json.load(f)
-
-    assert data_structures_no_code_list == filtered_metadata
+    with pytest.raises(DataNotFoundException) as e:
+        metadata.find_all_metadata_skip_code_list_and_missing_values(version='1.0.0.0')
 
 def __assert_code_list_and_missing_values(metadata):
 

--- a/tests/unit/domain/test_metadata.py
+++ b/tests/unit/domain/test_metadata.py
@@ -16,6 +16,13 @@ DATA_STRUCTURES_FILE_PATH = (
     'tests/resources/fixtures/api/data_structures.json'
 )
 
+METADATA_ALL_NO_CODE_LIST_FILE_PATH = (
+    'tests/resources/fixtures/domain/metadata_all_no_code_list__1_0_0_0.json'
+)
+
+DATA_STRUCTURES_NO_CODE_LIST_FILE_PATH = (
+    'tests/resources/fixtures/api/data_structures_no_code_list.json'
+)
 
 def test_find_two_data_structures_with_attrs(mocker):
     with open(METADATA_ALL_FILE_PATH, encoding='utf-8') as f:
@@ -171,6 +178,24 @@ def test_find_all_datastore_versions_when_draft_version_empty(mocker):
     assert len(actual['versions']) == 1
     assert actual['versions'][0]['version'] == '1.0.0.0'
 
+def test_find_all_metadata_skip_code_list_and_missing_values_for_metadata_all(mocker):
+    
+    with open(METADATA_ALL_FILE_PATH, encoding='utf-8') as f:
+        mocked_metadata_all = json.load(f)
+
+    mocker.patch.object(
+        datastore, 'get_metadata_all',
+        return_value=mocked_metadata_all
+    )
+    
+    filtered_metadata = metadata.find_all_metadata_skip_code_list_and_missing_values(version='1.0.0.0')
+    __assert_code_list_and_missing_values(filtered_metadata['dataStructures'])
+
+    with open(METADATA_ALL_NO_CODE_LIST_FILE_PATH, encoding='utf-8') as f:
+        metadata_no_code_list = json.load(f)
+
+    assert metadata_no_code_list == filtered_metadata
+
 def test_find_all_metadata_skip_code_list_and_missing_values_for_data_structures(mocker):
     
     with open(DATA_STRUCTURES_FILE_PATH, encoding='utf-8') as f:
@@ -184,18 +209,10 @@ def test_find_all_metadata_skip_code_list_and_missing_values_for_data_structures
     filtered_metadata = metadata.find_all_metadata_skip_code_list_and_missing_values(version='1.0.0.0')
     __assert_code_list_and_missing_values(filtered_metadata)
 
-def test_find_all_metadata_skip_code_list_and_missing_values_for_data_structures(mocker):
-    
-    with open(METADATA_ALL_FILE_PATH, encoding='utf-8') as f:
-        mocked_metadata_all = json.load(f)
+    with open(DATA_STRUCTURES_NO_CODE_LIST_FILE_PATH, encoding='utf-8') as f:
+        data_structures_no_code_list = json.load(f)
 
-    mocker.patch.object(
-        datastore, 'get_metadata_all',
-        return_value=mocked_metadata_all
-    )
-    
-    filtered_metadata = metadata.find_all_metadata_skip_code_list_and_missing_values(version='1.0.0.0')
-    __assert_code_list_and_missing_values(filtered_metadata['dataStructures'])
+    assert data_structures_no_code_list == filtered_metadata
 
 def __assert_code_list_and_missing_values(metadata):
 


### PR DESCRIPTION
optional parameter skip_code_lists that will filter (i.e. set the list to empty) the following list items: skip_code_lists, missingValues. Note that the default value is false which preserves the existing behaviour