### PR TITLE
Set host to correct value.

### DIFF
--- a/.test.env
+++ b/.test.env
@@ -1,1 +1,2 @@
 DATASTORE_ROOT_DIR=tests/resources
+DOCKER_HOST_NAME=localhost

--- a/metadata_service/config/environment.py
+++ b/metadata_service/config/environment.py
@@ -3,7 +3,8 @@ import os
 
 def _initialize_environment() -> dict:
     return {
-        'DATASTORE_ROOT_DIR': os.environ['DATASTORE_ROOT_DIR']
+        'DATASTORE_ROOT_DIR': os.environ['DATASTORE_ROOT_DIR'],
+        'DOCKER_HOST_NAME': os.environ['DOCKER_HOST_NAME']
     }
 
 

--- a/metadata_service/config/logging.py
+++ b/metadata_service/config/logging.py
@@ -1,9 +1,10 @@
 import json
-import platform
 import sys
 
 import json_logging
 import tomlkit
+
+from metadata_service.config import environment
 
 
 def _get_project_meta():
@@ -14,7 +15,7 @@ def _get_project_meta():
 
 
 pkg_meta = _get_project_meta()
-host = platform.node()
+host = environment.get('DOCKER_HOST_NAME')
 command = json.dumps(sys.argv)
 
 


### PR DESCRIPTION
The problem is that host is now logged by the value of container id like this: 

host | f1de49b09733
-- | --

What we need is to log the name of the Docker host, so the idea is to set an env variable in docker compose like this:

`DOCKER_HOST_NAME='$(cat /etc/hostname)'`
