### PR TITLE
Added --without-hashes to poetry export in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY poetry.lock pyproject.toml /app/
 # Install poetry and export dep endencies to requirements yaml
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.1.14
-RUN poetry export > requirements.txt
+RUN poetry export --without-hashes > requirements.txt
 
 # Production image
 FROM python:3.9-slim-bullseye


### PR DESCRIPTION
`docker build` wouldn't work, it said:

`ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==.
`

`poetry export --without-hashes` removed the error.

See discussion here:
[Poetry fails in CI/CD with ERROR](https://github.com/python-poetry/poetry/issues/3472)