### PR TITLE
Batch status check

### DIFF
--- a/metadata_service/api/metadata_api.py
+++ b/metadata_service/api/metadata_api.py
@@ -25,9 +25,11 @@ def get_data_store():
 @validate()
 def get_data_structure_current_status(query: NameParam):
     logger.info(
-        f'GET /metadata/data-structures/status with name = {query.name}'
+        f'GET /metadata/data-structures/status with name = {query.names}'
     )
-    response = jsonify(metadata.find_current_data_structure_status(query.name))
+    response = jsonify(
+        metadata.find_current_data_structure_status(query.get_names_as_list())
+    )
     response.headers.set('content-language', 'no')
     return response
 

--- a/metadata_service/api/request_models.py
+++ b/metadata_service/api/request_models.py
@@ -40,4 +40,7 @@ class MetadataQuery(BaseModel, extra=Extra.forbid, validate_assignment=True):
 
 
 class NameParam(BaseModel, extra=Extra.forbid):
-    name: str
+    names: str
+
+    def get_names_as_list(self) -> List[str]:
+        return self.names.split(',')

--- a/metadata_service/domain/metadata.py
+++ b/metadata_service/domain/metadata.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import List
+from typing import List, Union
 from metadata_service.adapter import datastore
 from metadata_service.domain.version import Version
 from metadata_service.exceptions.exceptions import (
@@ -18,7 +18,9 @@ def find_all_datastore_versions():
     return datastore_versions
 
 
-def find_current_data_structure_status(status_query_names: List[str]):
+def find_current_data_structure_status(
+        status_query_names: List[str]
+) -> dict[str, Union[dict, None]]:
     datastore_versions = find_all_datastore_versions()
     datastructure_statuses = {}
     for version in datastore_versions['versions']:
@@ -32,8 +34,11 @@ def find_current_data_structure_status(status_query_names: List[str]):
                     'releaseTime': version['releaseTime'],
                     'releaseStatus': data_structure['releaseStatus']
                 }
-    return datastructure_statuses
-
+    return {
+        name: datastructure_statuses.get(name, None)
+        for name in status_query_names
+    }
+    
 
 def find_data_structures(
     names: list[str],

--- a/tests/unit/api/test_metadata_api.py
+++ b/tests/unit/api/test_metadata_api.py
@@ -85,7 +85,7 @@ def test_get_current_data_structure_status(flask_app, mocker):
     response: Response = flask_app.get(
         url_for(
             'metadata_api.get_data_structure_current_status',
-            name='INNTEKT_TJENPEN'
+            names='INNTEKT_TJENPEN'
         ),
         headers={
             'X-Request-ID': 'test-123',
@@ -93,7 +93,29 @@ def test_get_current_data_structure_status(flask_app, mocker):
             'Accept': 'application/json'
         })
     spy.assert_called_with(
-        MOCKED_DATASTRUCTURE['name']
+        [MOCKED_DATASTRUCTURE['name']]
+    )
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json == MOCKED_DATASTRUCTURE
+
+
+def test_get_multiple_data_structure_status(flask_app, mocker):
+    spy = mocker.patch.object(
+        metadata, 'find_current_data_structure_status',
+        return_value=MOCKED_DATASTRUCTURE
+    )
+    response: Response = flask_app.get(
+        url_for(
+            'metadata_api.get_data_structure_current_status',
+            names='INNTEKT_TJENPEN,INNTEKT_TO'
+        ),
+        headers={
+            'X-Request-ID': 'test-123',
+            'Accept-Language': 'no',
+            'Accept': 'application/json'
+        })
+    spy.assert_called_with(
+        ['INNTEKT_TJENPEN', 'INNTEKT_TO']
     )
     assert response.headers['Content-Type'] == 'application/json'
     assert response.json == MOCKED_DATASTRUCTURE

--- a/tests/unit/domain/test_metadata.py
+++ b/tests/unit/domain/test_metadata.py
@@ -121,41 +121,64 @@ def test_find_current_data_structure_status(mocker):
         return_value=mocked_draft_version
     )
     actual_draft = metadata.find_current_data_structure_status(
-        'TEST_PERSON_HOBBIES'
+        ['TEST_PERSON_HOBBIES']
     )
     actual_pending_release = metadata.find_current_data_structure_status(
-        'TEST_PERSON_SAVINGS'
+        ['TEST_PERSON_SAVINGS']
     )
     actual_released = metadata.find_current_data_structure_status(
-        'TEST_PERSON_PETS'
+        ['TEST_PERSON_PETS']
     )
     actual_removed = metadata.find_current_data_structure_status(
-        'TEST_PERSON_INCOME'
+        ['TEST_PERSON_INCOME']
     )
-    assert actual_draft == {
-        "name": "TEST_PERSON_HOBBIES",
-        "operation": "ADD",
-        "releaseTime": 1608000000,
-        "releaseStatus": "DRAFT"
+    actual_all = metadata.find_current_data_structure_status(
+        [
+            'TEST_PERSON_INCOME',
+            'TEST_PERSON_PETS',
+            'TEST_PERSON_SAVINGS',
+            'TEST_PERSON_HOBBIES'
+        ]
+    )
+    expected_draft = {
+        "TEST_PERSON_HOBBIES": {
+            "operation": "ADD",
+            "releaseTime": 1608000000,
+            "releaseStatus": "DRAFT"
+        }
     }
-    assert actual_pending_release == {
-        "name": "TEST_PERSON_SAVINGS",
-        "operation": "ADD",
-        "releaseTime": 1608000000,
-        "releaseStatus": "PENDING_RELEASE"
+    expected_pending_release = {
+        "TEST_PERSON_SAVINGS": {
+            "operation": "ADD",
+            "releaseTime": 1608000000,
+            "releaseStatus": "PENDING_RELEASE"
+        }
     }
-    assert actual_released == {
-        "name": "TEST_PERSON_PETS",
-        "operation": "ADD",
-        "releaseTime": 1607332752,
-        "releaseStatus": "RELEASED"
+    expected_released = {
+        "TEST_PERSON_PETS": {
+            "operation": "ADD",
+            "releaseTime": 1607332752,
+            "releaseStatus": "RELEASED"
+        }
     }
-    assert actual_removed == {
-        "name": "TEST_PERSON_INCOME",
-        "operation": "REMOVE",
-        "releaseTime": 1607332762,
-        "releaseStatus": "DELETED"
+    expected_removed = {
+        "TEST_PERSON_INCOME": {
+            "operation": "REMOVE",
+            "releaseTime": 1607332762,
+            "releaseStatus": "DELETED"
+        }
     }
+    expected_all = {
+        **expected_draft,
+        **expected_pending_release,
+        **expected_released,
+        **expected_removed
+    }
+    assert actual_draft == expected_draft
+    assert actual_pending_release == expected_pending_release
+    assert actual_released == expected_released
+    assert actual_removed == expected_removed
+    assert actual_all == expected_all
 
 
 def test_find_all_datastore_versions(mocker):

--- a/tests/unit/domain/test_metadata.py
+++ b/tests/unit/domain/test_metadata.py
@@ -132,12 +132,16 @@ def test_find_current_data_structure_status(mocker):
     actual_removed = metadata.find_current_data_structure_status(
         ['TEST_PERSON_INCOME']
     )
+    actual_no_such_dataset = metadata.find_current_data_structure_status(
+        ['NO_SUCH_DATASET']
+    )
     actual_all = metadata.find_current_data_structure_status(
         [
             'TEST_PERSON_INCOME',
             'TEST_PERSON_PETS',
             'TEST_PERSON_SAVINGS',
-            'TEST_PERSON_HOBBIES'
+            'TEST_PERSON_HOBBIES',
+            'NO_SUCH_DATASET'
         ]
     )
     expected_draft = {
@@ -146,6 +150,9 @@ def test_find_current_data_structure_status(mocker):
             "releaseTime": 1608000000,
             "releaseStatus": "DRAFT"
         }
+    }
+    expected_no_such_dataset = {
+        "NO_SUCH_DATASET": None
     }
     expected_pending_release = {
         "TEST_PERSON_SAVINGS": {
@@ -172,12 +179,14 @@ def test_find_current_data_structure_status(mocker):
         **expected_draft,
         **expected_pending_release,
         **expected_released,
-        **expected_removed
+        **expected_removed,
+        **expected_no_such_dataset
     }
     assert actual_draft == expected_draft
     assert actual_pending_release == expected_pending_release
     assert actual_released == expected_released
     assert actual_removed == expected_removed
+    assert actual_no_such_dataset == expected_no_such_dataset
     assert actual_all == expected_all
 
 


### PR DESCRIPTION
Update endpoint to be able to check status of multiple datasets. Still accepts a single name as a string in query. Multiple datasets must be a comma-separated lists.