### PR TITLE
New POST endpoint for dataset statuses

### DIFF
--- a/metadata_service/api/metadata_api.py
+++ b/metadata_service/api/metadata_api.py
@@ -34,6 +34,19 @@ def get_data_structure_current_status(query: NameParam):
     return response
 
 
+@metadata_api.post("/metadata/data-structures/status")
+@validate()
+def get_data_structure_current_status_as_post(body: NameParam):
+    logger.info(
+        f"POST /metadata/data-structures/status with name = {body.names}"
+    )
+    response = jsonify(
+        metadata.find_current_data_structure_status(body.get_names_as_list())
+    )
+    response.headers.set("content-language", "no")
+    return response
+
+
 @metadata_api.get("/metadata/data-structures")
 @validate()
 def get_data_structures(query: MetadataQuery):

--- a/tests/unit/api/test_metadata_api.py
+++ b/tests/unit/api/test_metadata_api.py
@@ -41,6 +41,24 @@ MOCKED_DATASTRUCTURE = {
     "releaseTime": 123123,
 }
 
+MOCKED_DATASTRUCTURES = [
+    {
+        "INNTEKT_TJENPEN": {
+            "description": "dummy",
+            "operation": "ADD",
+            "releaseTime": 123123,
+        }
+    },
+    {
+        "INNTEKT_BANKINNSK": {
+            "description": "dummy",
+            "operation": "ADD",
+            "releaseTime": 123123,
+        }
+    },
+]
+
+
 MOCKED_LANGUAGES = [
     {"code": "no", "label": "Norsk"},
     {"code": "en", "label": "English"},
@@ -95,22 +113,27 @@ def test_get_current_data_structure_status_as_post(flask_app, mocker):
     spy = mocker.patch.object(
         metadata,
         "find_current_data_structure_status",
-        return_value=MOCKED_DATASTRUCTURE,
+        return_value=MOCKED_DATASTRUCTURES,
     )
     response: Response = flask_app.post(
-        url_for(
-            "metadata_api.get_data_structure_current_status_as_post"),
-        json={"names": "INNTEKT_TJENPEN"},
+        url_for("metadata_api.get_data_structure_current_status_as_post"),
+        json={
+            "names": f"{next(iter(MOCKED_DATASTRUCTURES[0]))},{next(iter(MOCKED_DATASTRUCTURES[1]))}"
+        },
         headers={
             "X-Request-ID": "test-123",
             "Accept-Language": "no",
             "Accept": "application/json",
-            "Content-Type": "application/json"
         },
     )
-    spy.assert_called_with([MOCKED_DATASTRUCTURE["name"]])
+    spy.assert_called_with(
+        [
+            f"{next(iter(MOCKED_DATASTRUCTURES[0]))}",
+            f"{next(iter(MOCKED_DATASTRUCTURES[1]))}",
+        ]
+    )
     assert response.headers["Content-Type"] == "application/json"
-    assert response.json == MOCKED_DATASTRUCTURE
+    assert response.json == MOCKED_DATASTRUCTURES
 
 
 def test_get_multiple_data_structure_status(flask_app, mocker):

--- a/tests/unit/api/test_metadata_api.py
+++ b/tests/unit/api/test_metadata_api.py
@@ -41,22 +41,18 @@ MOCKED_DATASTRUCTURE = {
     "releaseTime": 123123,
 }
 
-MOCKED_DATASTRUCTURES = [
-    {
-        "INNTEKT_TJENPEN": {
-            "description": "dummy",
-            "operation": "ADD",
-            "releaseTime": 123123,
-        }
+MOCKED_DATASTRUCTURES = {
+    "INNTEKT_TJENPEN": {
+        "description": "dummy",
+        "operation": "ADD",
+        "releaseTime": 123123,
     },
-    {
-        "INNTEKT_BANKINNSK": {
-            "description": "dummy",
-            "operation": "ADD",
-            "releaseTime": 123123,
-        }
+    "INNTEKT_BANKINNSK": {
+        "description": "dummy",
+        "operation": "ADD",
+        "releaseTime": 123123,
     },
-]
+}
 
 
 MOCKED_LANGUAGES = [
@@ -117,21 +113,14 @@ def test_get_current_data_structure_status_as_post(flask_app, mocker):
     )
     response: Response = flask_app.post(
         url_for("metadata_api.get_data_structure_current_status_as_post"),
-        json={
-            "names": f"{next(iter(MOCKED_DATASTRUCTURES[0]))},{next(iter(MOCKED_DATASTRUCTURES[1]))}"
-        },
+        json={"names": ",".join(list(MOCKED_DATASTRUCTURES.keys()))},
         headers={
             "X-Request-ID": "test-123",
             "Accept-Language": "no",
             "Accept": "application/json",
         },
     )
-    spy.assert_called_with(
-        [
-            f"{next(iter(MOCKED_DATASTRUCTURES[0]))}",
-            f"{next(iter(MOCKED_DATASTRUCTURES[1]))}",
-        ]
-    )
+    spy.assert_called_with(list(MOCKED_DATASTRUCTURES.keys()))
     assert response.headers["Content-Type"] == "application/json"
     assert response.json == MOCKED_DATASTRUCTURES
 

--- a/tests/unit/api/test_metadata_api.py
+++ b/tests/unit/api/test_metadata_api.py
@@ -91,6 +91,28 @@ def test_get_current_data_structure_status(flask_app, mocker):
     assert response.json == MOCKED_DATASTRUCTURE
 
 
+def test_get_current_data_structure_status_as_post(flask_app, mocker):
+    spy = mocker.patch.object(
+        metadata,
+        "find_current_data_structure_status",
+        return_value=MOCKED_DATASTRUCTURE,
+    )
+    response: Response = flask_app.post(
+        url_for(
+            "metadata_api.get_data_structure_current_status_as_post"),
+        json={"names": "INNTEKT_TJENPEN"},
+        headers={
+            "X-Request-ID": "test-123",
+            "Accept-Language": "no",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+    )
+    spy.assert_called_with([MOCKED_DATASTRUCTURE["name"]])
+    assert response.headers["Content-Type"] == "application/json"
+    assert response.json == MOCKED_DATASTRUCTURE
+
+
 def test_get_multiple_data_structure_status(flask_app, mocker):
     spy = mocker.patch.object(
         metadata,


### PR DESCRIPTION
This POST endpoint will help avoid max query length on GET requests in case there are a lot of datasets in the query.