### PR TITLE
logging_fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ RUN pip install -r requirements.txt
 # Change user
 USER microdata
 
-CMD ["gunicorn", "metadata_service.app:app", "--workers", "1", "--limit-request-line", "8190"]
+CMD ["gunicorn", "--logger-class", "metadata_service.config.gunicorn.CustomLogger", "metadata_service.app:app", "--workers", "1", "--limit-request-line", "8190"]

--- a/metadata_service/app.py
+++ b/metadata_service/app.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import msgpack
 from flask import Flask, Response, request, jsonify, make_response
@@ -17,8 +16,6 @@ from metadata_service.exceptions.exceptions import (
 
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler(sys.stdout))
 
 app = Flask(__name__)
 app.register_blueprint(observability)

--- a/metadata_service/config/gunicorn.py
+++ b/metadata_service/config/gunicorn.py
@@ -18,7 +18,7 @@ class CustomLogger(glogging.Logger):
                 fmt=(
                     '{"@timestamp": "%(asctime)s",'
                     '"pid": "%(process)d", '
-                    '"loggerName": "guvicorn_custom",'
+                    '"loggerName": "gunicorn_custom",'
                     '"levelName": "%(levelname)s",'
                     '"schemaVersion": "v3",'
                     '"serviceVersion": "TODO",'


### PR DESCRIPTION
- Gunicorn was not configured with a custom logger. This led to it using the root logger, but missing the request context, causing the logger to crash. This is fixed by giving gunicorn its own logger that we already configured.
- The logger crashes if one of the fields it tries to fetch from the global request context is not present. We make sure the @before_request middleware initialize all logging fields
- There was no "request_logging" on response. Added this in the @after_request middleware so we get logging of response_status and response_time_ms