### PR TITLE
logging_datetime_fix

### DIFF
--- a/metadata_service/config/logging.py
+++ b/metadata_service/config/logging.py
@@ -38,7 +38,8 @@ class MicrodataJSONFormatter(logging.Formatter):
                 "@timestamp": datetime.datetime.fromtimestamp(
                     record.created,
                     tz=datetime.timezone.utc,
-                ).isoformat(),
+                ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+                + "Z",
                 "command": self.command,
                 "error.stack": record.__dict__.get("exc_info"),
                 "host": self.host,


### PR DESCRIPTION
It seems like kibana accepts the timestamp either way, but this is exactly formatted the way it was before the logging updates. What do we think?
also affects: https://github.com/statisticsnorway/microdata-data-service/pull/127